### PR TITLE
add manual validation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
   "ignore": [],
   "dependencies": {
     "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^0.9.0",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^0.9.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^0.9.0",
     "paper-input": "PolymerElements/paper-input#^0.9.0",
     "paper-styles": "PolymerElements/paper-styles#^0.9.0",

--- a/date-input.html
+++ b/date-input.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 <link rel="import" href="date-validator.html">
 
 <dom-module id="date-input">
@@ -30,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
   <template>
-    <date-validator></date-validator>
+    <date-validator id="validator"></date-validator>
 
     <div class="horizontal layout">
       <input is="iron-input"
@@ -38,6 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           maxlength="2"
           bind-value="{{month}}"
           placeholder="MM"
+          allowed-pattern="[0-9]"
+          prevent-invalid-input
           class="flex">
       <span>/</span>
       <input is="iron-input"
@@ -45,6 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           maxlength="2"
           bind-value="{{year}}"
           placeholder="YY"
+          allowed-pattern="[0-9]"
+          prevent-invalid-input
           class="flex">
     </div>
   </template>
@@ -107,7 +112,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Months are 0-11.
       this.date = {month: month, year: year};
       this.fire('dateChanged', this.date);
-    }
+    },
+
+    validate:function () {
+      this.invalid = !this.$.validator.validate(this.date);
+      this.fire('iron-input-validate');
+      return !this.invalid;
+    },
 
   })
 })();

--- a/gold-cc-expiration-input.html
+++ b/gold-cc-expiration-input.html
@@ -47,14 +47,14 @@ Example:
         <label>[[label]]</label>
       </template>
 
-      <date-input class="paper-input-input"
+      <date-input class="paper-input-input" id="input"
           required$="[[required]]"
           month="[[_computeMonth(value)]]"
           year="[[_computeYear(value)]]">
       </date-input>
 
       <template is="dom-if" if="[[errorMessage]]">
-        <paper-input-error id="error">[[errorMessage]]</paper-input-error>
+        <paper-input-error>[[errorMessage]]</paper-input-error>
       </template>
 
     </paper-input-container>


### PR DESCRIPTION
- added a `form-element-behavior`, so that it can register with an `iron-form`
- added a `validate()` method which fires `iron-input-validate`, just like `iron-input`, so that the `paper-input-container` that holds everything is notified correctly
- numbers-only constraints on the inputs