### PR TITLE
ff fixes

### DIFF
--- a/date-input.html
+++ b/date-input.html
@@ -28,6 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       @apply(--paper-input-container-font);
       opacity: 0.33;
     }
+
   </style>
 
   <template>
@@ -41,6 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           placeholder="MM"
           allowed-pattern="[0-9]"
           prevent-invalid-input
+          autocomplete$="[[autocomplete]]"
           class="flex">
       <span>/</span>
       <input is="iron-input"
@@ -50,6 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           placeholder="YY"
           allowed-pattern="[0-9]"
           prevent-invalid-input
+          autocomplete$="[[autocomplete]]"
           class="flex">
     </div>
   </template>

--- a/gold-cc-expiration-input.html
+++ b/gold-cc-expiration-input.html
@@ -52,7 +52,8 @@ Example:
       <date-input class="paper-input-input" id="input"
           required$="[[required]]"
           month="[[_computeMonth(value)]]"
-          year="[[_computeYear(value)]]">
+          year="[[_computeYear(value)]]"
+          autocomplete$="[[autocomplete]]">
       </date-input>
 
       <template is="dom-if" if="[[errorMessage]]">


### PR DESCRIPTION
This fixes:

- inputs have a min width in Firefox, which means the MM/YY were being pushed out
- NVDA on Firefox reads "autocomplete" if the attribute isn't set