### PR TITLE
update docs

### DIFF
--- a/gold-cc-expiration-input.html
+++ b/gold-cc-expiration-input.html
@@ -17,12 +17,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="date-input.html">
 
 <!--
-`gold-cc-expiration-input` is a Material Design field for entering a valid,
-future date representing a credit card's expiration date.
-Example:
+`gold-cc-expiration-input` is a  single-line text field with Material Design styling
+for entering a credit card's expiration date
 
     <gold-cc-expiration-input></gold-cc-expiration-input>
     <gold-cc-expiration-input value="11/15"></gold-cc-expiration-input>
+
+It may include an optional label, which by default is "Expiration Date".
+
+    <gold-cc-expiration-input label="Date"></gold-cc-expiration-input>
+
+
+### Validation
+
+The input can check whether the entered date is a valid, future date.
+
+The input can be automatically validated as the user is typing by using
+the `auto-validate` and `required` attributes. For manual validation, the
+element also has a `validate()` method, which returns the validity of the
+input as well sets any appropriate error messages and styles.
+
+See `Polymer.PaperInputBehavior` for more API docs.
+
+### Styling
+
+See `Polymer.PaperInputContainer` for a list of custom properties used to
+style this element.
 
 @group Gold Elements
 @hero hero.svg


### PR DESCRIPTION
Docs! Blatantly lifted from `paper-input` and carried across all the gold elements.

/cc @cdata