### PR TITLE
add autocomplete field

### DIFF
--- a/date-input.html
+++ b/date-input.html
@@ -58,7 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           placeholder="MM"
           allowed-pattern="[0-9]"
           prevent-invalid-input
-          autocomplete$="[[autocomplete]]"
+          autocomplete="cc-exp-month"
           class="flex">
       <span>/</span>
       <input is="iron-input"
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           placeholder="YY"
           allowed-pattern="[0-9]"
           prevent-invalid-input
-          autocomplete$="[[autocomplete]]"
+          autocomplete="cc-exp-year"
           class="flex">
     </div>
   </template>


### PR DESCRIPTION
Apparently the `autocomplete` field has meaning. See: https://developers.google.com/web/fundamentals/input/form/label-and-name-inputs?hl=en

It worked by magic in some of the elements because they had a heuristic-approved name in the demo, but now it works regardless of the name.

/cc @morethanreal @cdata 
