### PR TITLE
use the right mobile keyboard

### DIFF
--- a/date-input.html
+++ b/date-input.html
@@ -59,6 +59,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           allowed-pattern="[0-9]"
           prevent-invalid-input
           autocomplete="cc-exp-month"
+          type="tel"
           class="flex">
       <span>/</span>
       <input is="iron-input"
@@ -70,6 +71,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           allowed-pattern="[0-9]"
           prevent-invalid-input
           autocomplete="cc-exp-year"
+          type="tel"
           class="flex">
     </div>
   </template>


### PR DESCRIPTION
Both inputs are number only, so they should bring up the numbers-only keyboard.