### PR TITLE
validate input on blur

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h4>Standard</h4>
     <div class="vertical-section">
       <gold-cc-expiration-input></gold-cc-expiration-input>
-      <gold-cc-expiration-input label="Auto-validating" auto-validate></gold-cc-expiration-input>
+      <gold-cc-expiration-input label="Auto-validating" auto-validate required></gold-cc-expiration-input>
     </div>
 
     <h4>Pre-validated</h4>
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <gold-cc-expiration-input auto-validate value="11/"></gold-cc-expiration-input>
     </div>
 
-    <h4>Custom error message</h4>
+    <h4>Custom error message, auto-validates on blur</h4>
     <div class="vertical-section">
       <gold-cc-expiration-input required auto-validate error-message="Please enter a valid date" label="Credit Card Expiration"></gold-cc-expiration-input>
     </div>

--- a/gold-cc-expiration-input.html
+++ b/gold-cc-expiration-input.html
@@ -61,7 +61,6 @@ style this element.
 
     <paper-input-container id="container"
         always-float-label
-        auto-validate="[[autoValidate]]"
         attr-for-value="date"
         disabled$="[[disabled]]"
         invalid="[[invalid]]">
@@ -110,6 +109,11 @@ style this element.
       label: {
         type: String,
         value: "Expiration Date"
+      },
+
+      value: {
+        value: '',
+        observer: '_onValueChanged'
       }
     },
 
@@ -117,9 +121,31 @@ style this element.
       'dateChanged': '_dateChanged'
     },
 
+    observers: [
+      '_onFocusedChanged(focused)'
+    ],
+
+    ready: function() {
+      // If there's an initial input, validate it.
+      if (this.value)
+        this._handleAutoValidate();
+    },
+
+    /**
+     * A handler that is called on input
+     */
+    _onValueChanged: function(value, oldValue) {
+      // The initial property assignment is handled by `ready`.
+      if (oldValue == undefined)
+        return;
+
+      this._handleAutoValidate();
+    },
+
     _dateChanged: function(event) {
-      if (event.detail.month && event.detail.year)
+      if (event.detail.month && event.detail.year) {
         this.value = event.detail.month + '/' + event.detail.year;
+      }
     },
 
     _computeMonth: function(value) {
@@ -130,6 +156,22 @@ style this element.
     _computeYear: function(value) {
       // Date is in MM/YY format.
       return value.split('/')[1];
+    },
+
+    /**
+     * Overidden from Polymer.PaperInputBehavior.
+     */
+    validate: function() {
+      return this.$.input.validate();
+    },
+
+    /**
+     * Overidden from Polymer.IronControlState.
+     */
+    _onFocusedChanged: function(focused) {
+      if (!focused) {
+        this._handleAutoValidate();
+      }
     }
       
   })

--- a/test/basic.html
+++ b/test/basic.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <script src="../../iron-test-helpers/test-helpers.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../gold-cc-expiration-input.html">
@@ -47,6 +48,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
         assert.isTrue(container.invalid);
+
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
       });
 
       test('misformed dates are not ok', function() {
@@ -57,6 +62,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
         assert.isTrue(container.invalid);
+
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
       });
 
       test('past dates are not ok', function() {
@@ -67,6 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
         assert.isTrue(container.invalid);
+
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
       });
 
       test('future dates are ok', function() {
@@ -78,7 +91,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
         assert.isFalse(container.invalid);
-        assert.equal(input.value, '11/99')
+        assert.equal(input.value, '11/99');
+
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
       });
 
       test('value is updated correctly ', function() {
@@ -88,13 +105,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(input.value, '11/15');
       });
 
-      test('empty required input shows error', function() {
+      test('empty required input shows error on blur', function(done) {
         var input = fixture('basic');
         forceXIfStamp(input);
 
         var error = Polymer.dom(input.root).querySelector('paper-input-error');
         assert.ok(error, 'paper-input-error exists');
-        assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
+
+        assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+
+        input.addEventListener('blur', function(event) {
+          assert(!input.focused, 'input is blurred');
+          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+          done();
+        });
+        MockInteractions.focus(input.inputElement);
+        MockInteractions.blur(input.inputElement);
       });
 
     });


### PR DESCRIPTION
This matches the behaviour in these other PRs:
- [ ] https://github.com/PolymerElements/paper-input/pull/148
- [ ] https://github.com/PolymerElements/gold-phone-input/pull/28
- [ ] https://github.com/PolymerElements/gold-cc-input/pull/29
- [ ] https://github.com/PolymerElements/gold-cc-cvc-input/pull/23
- [ ] https://github.com/PolymerElements/gold-email-input/pull/29

Removing the `inline-block` on the child custom element also fixes https://github.com/PolymerElements/gold-cc-expiration-input/issues/20