### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
@@ -32,7 +33,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/date-input.html
+++ b/date-input.html
@@ -9,8 +9,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-input/iron-input.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
+<link rel="import" href="../paper-input/paper-input-container.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/typography.html">
+
 <link rel="import" href="date-validator.html">
 
 <dom-module id="date-input">
@@ -33,8 +37,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color: var(--paper-input-container-input-color, --primary-text-color);
       text-align: center;
 
+      @apply(--layout-flex);
       @apply(--paper-font-subhead);
       @apply(--paper-input-container-input);
+    }
+
+    .container {
+      @apply(--layout-horizontal);
     }
 
   </style>
@@ -45,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <span aria-hidden id="monthLabel" hidden>Month</span>
     <span aria-hidden id="yearLabel" hidden>Year</span>
 
-    <div class="horizontal layout">
+    <div class="container">
       <input is="iron-input"
           aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'monthLabel')]]"
           required$="[[required]]"
@@ -56,7 +65,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           prevent-invalid-input
           autocomplete="cc-exp-month"
           type="tel"
-          class="flex"
           disabled$="[[disabled]]"
           invalid="{{invalid}}"
           autofocus$="[[autofocus]]"
@@ -75,7 +83,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           prevent-invalid-input
           autocomplete="cc-exp-year"
           type="tel"
-          class="flex"
           disabled$="[[disabled]]"
           invalid="{{invalid}}"
           autofocus$="[[autofocus]]"

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,8 +19,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../gold-cc-expiration-input.html">
-
-  <link rel="stylesheet" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
 </head>
 <style>

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,12 +20,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <script src="../../iron-test-helpers/test-helpers.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../gold-cc-expiration-input.html">
 
 </head>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way