### PR TITLE
Slash key on month input selects year input

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
+    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.1.0"

--- a/date-input.html
+++ b/date-input.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-input/paper-input-container.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../iron-a11y-keys/iron-a11y-keys.html">
 
 <link rel="import" href="date-validator.html">
 
@@ -54,8 +55,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <span aria-hidden id="monthLabel" hidden>Month</span>
     <span aria-hidden id="yearLabel" hidden>Year</span>
 
+    <iron-a11y-keys id="a11y-month" target="[[expirationMonth]]" keys="/"
+        on-keys-pressed="_selectYear"></iron-a11y-keys>
     <div class="container">
       <input is="iron-input"
+          id="expirationMonth"
           aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'monthLabel')]]"
           required$="[[required]]"
           maxlength="2"
@@ -119,6 +123,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: String
       },
 
+      expirationMonth: {
+        type: Object,
+        value: function() {
+          return this.$.expirationMonth;
+        }
+      },
+
       /**
        * The year component of the date displayed.
        */
@@ -157,6 +168,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (month.length === 2) {
         this.$.expirationYear.focus();
       }
+    },
+
+    _selectYear: function() {
+      this.$.expirationYear.select();
     },
 
     validate: function() {


### PR DESCRIPTION
Allows a date typed with a slash to populate the inputs (eg: '2/16')

Fixes #36 

