### PR TITLE
minor fixes and style cleanup

### DIFF
--- a/date-input.html
+++ b/date-input.html
@@ -137,8 +137,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       ariaLabelPrefix: {
         type:String
-      }
+      },
 
+      /**
+       * Set to true to disable the month and year input elements.
+       */
+      disabled: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * Set to true to autofocus the month input element.
+       */
+      autofocus: {
+        type: Boolean
+      },
+
+      /**
+       * Bound to the month and year input elements' `inputmode` property.
+       */
+      inputmode: {
+        type: String
+      },
+
+      /**
+       * Set to true to mark the month and year inputs as not editable.
+       */
+      readonly: {
+        type: Boolean,
+        value: false
+      }
     },
 
     observers: [

--- a/date-input.html
+++ b/date-input.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="date-validator.html">
 
 <dom-module id="date-input">
-
+  <template>
   <style>
     span {
       @apply(--paper-input-container-font);
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       text-align: center;
     }
 
-    input {
+    input[is="iron-input"] {
       position: relative; /* to make a stacking context */
       outline: none;
       box-shadow: none;
@@ -45,10 +45,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     .container {
       @apply(--layout-horizontal);
     }
-
   </style>
 
-  <template>
     <date-validator id="validator"></date-validator>
 
     <span aria-hidden id="monthLabel" hidden>Month</span>
@@ -85,7 +83,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type="tel"
           disabled$="[[disabled]]"
           invalid="{{invalid}}"
-          autofocus$="[[autofocus]]"
           inputmode$="[[inputmode]]"
           readonly$="[[readonly]]">
     </div>
@@ -171,6 +168,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _computeAriaLabel: function(dateLabel, monthLabel) {
       return dateLabel + ' ' + monthLabel;
     }
-
   });
 </script>

--- a/date-input.html
+++ b/date-input.html
@@ -19,33 +19,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="date-input">
   <template>
-  <style>
-    span {
-      @apply(--paper-input-container-font);
-      opacity: 0.33;
-      text-align: center;
-    }
+    <style>
+      span {
+        @apply(--paper-input-container-font);
+        opacity: 0.33;
+        text-align: center;
+      }
 
-    input[is="iron-input"] {
-      position: relative; /* to make a stacking context */
-      outline: none;
-      box-shadow: none;
-      padding: 0;
-      width: 100%;
-      background: transparent;
-      border: none;
-      color: var(--paper-input-container-input-color, --primary-text-color);
-      text-align: center;
+      input[is="iron-input"] {
+        position: relative; /* to make a stacking context */
+        outline: none;
+        box-shadow: none;
+        padding: 0;
+        width: 100%;
+        background: transparent;
+        border: none;
+        color: var(--paper-input-container-input-color, --primary-text-color);
+        text-align: center;
 
-      @apply(--layout-flex);
-      @apply(--paper-font-subhead);
-      @apply(--paper-input-container-input);
-    }
+        @apply(--layout-flex);
+        @apply(--paper-font-subhead);
+        @apply(--paper-input-container-input);
+      }
 
-    .container {
-      @apply(--layout-horizontal);
-    }
-  </style>
+      .container {
+        @apply(--layout-horizontal);
+      }
+    </style>
 
     <date-validator id="validator"></date-validator>
 

--- a/gold-cc-expiration-input.html
+++ b/gold-cc-expiration-input.html
@@ -60,7 +60,8 @@ style this element.
     </style>
 
     <paper-input-container id="container"
-        always-float-label
+        no-label-float="[[noLabelFloat]]"
+        always-float-label="[[alwaysFloatLabel]]"
         attr-for-value="date"
         disabled$="[[disabled]]"
         invalid="[[invalid]]">
@@ -94,6 +95,11 @@ style this element.
       Polymer({
 
         is: 'gold-cc-expiration-input',
+
+        /* The underlying dateInput is tabbable */
+        hostAttributes: {
+          'tabindex': -1
+        },
 
         behaviors: [
           Polymer.PaperInputBehavior,


### PR DESCRIPTION
Fixes:
- fixed https://github.com/PolymerElements/gold-cc-expiration-input/issues/45 by skipping the `gold-cc-expiration-input` itself, since its nested `input`s are tabbable
- fixed https://github.com/PolymerElements/gold-cc-expiration-input/issues/46 by passing down the `no-label-float` attribute (the underlying `paper-input-container` knows how to deal with it)
- fixed https://github.com/PolymerElements/gold-cc-expiration-input/issues/44 by correctly defining the bound properties

Cleanup:
- `date-input`: moved the `<style>` inside the `<template>` as per Polymer 1.1.0
- noticed that the input text wasn't centered in the shady dom (but was in the shadow DOM)
- inside `date-input`, both the month AND the year were getting the `autofocus` attribute, which makes no sense. only one field should to have it 😅