### PR TITLE
2.0 Hybrid Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polylint web-component-tester
-  - bower install
-  - polylint
+  - npm install -g polymer-cli
+  - polymer install --variants
 env:
   global:
     - secure: >-
         Qe0WSR8xqRBZgXFr5yzHQBlcG2g4y4N0tH0rDCbFU4/Nf75ADDf5/8bWGbI9hAIyXj8CP27BkZvPClx6vLm+m45yjNBRXuUw5YrSSjqKMNxIGx7gajXYbQn/LRgv7e9t7H0htYXWZ2/1wEDtoqlrTL8oKGvGfpRHFkeV00kYPKqG7BgZBaXNc9HJIXHKW7Pq8kqPR9zlqvmIskrStZ7VapldfgfMWOuI1Tl5i65+YuGT2IDsvaykVhwjP6dtTrJeE4ACt8jN+l7vRoyoEXZDfCZQoBXPhomMxr0g1wrSHohG3PW+IMcyUy0sMgYLBmGuxENsdSIzlzlyVpWt2U1+5RQY5cEh7P7616pCZx8VLjhsTh4plLrx87ycTEvjTw91OJJzlSQYP55RmZJWQs9rRHyKHZf6n4WRyiG+7+8DfSCs8lAvpohHFvG2y28sxSWctKVmGjK0h6k/Q/sCxCxRN4+Bq5ByHCeuE0VsVyzSVPJYw49VE1N3vQQxYioEuxxI1y6y8EORBOK7hf1QoVKRPtmJ4keWybkLAhNRFhAlaSmaRyI2A+q5yyLSdk8LrxP93GJxQe0bI0sU3V65jrDRHWtdjDK+2tzhwLWkbxt0eZiywz77b/q0BY6eKddJ40zZTdgXIZ4Es4gxM9mZYRAmTcKVGoYMNPJCD3ep3213w1Y=
     - secure: >-
         OJAW+ssXIXb+2Ze4skRm4QrFY6OcpFgKHRhcdT5TGv6OpzHPZO5wWgX37Ocb2FtgGbiIAMiI1B6dR4C998LGOUVO7kGA1f7vnp75PvsvYON1sKLfAyuIBJuI6uLRE6jOSUDAG9Rc3Q3Hv33QOnDcC1uwuYDFIF8pjn++TPqx3c0WwapD+IBsnHhFsTi3H7d0vwJNRUprAZq4leo+3f/jz4PMWlV7IxrjG0ghseOO4sEXDLkm6GXeaJV78HCoNFk/14LC947BxN6T5Sc9lzWo/s0t8JoZODjAe6uON9OzfgsCs8oH7hhNys8QM/6EqBgcL2sEvJi9N0vsBKG351DHVFjGMv7j28+N/FzYkrrtET6EyPxcZ7S3TYUQb92hW/cMBJ6lqusmGfzFQ56WnAJyKJei0vH+IykBFBJ+Km2X3DS3/i30l0j8w4dN0vjYkAC+oWGho5iDN8cp5K93cLhgnDhPr6fU2tRMHB3bPjRMGgT+TmP9zJJ87mSiwCJgJJGl8NVODz54e66CZcOPZdTBzsdC7YSfvlvUE7PUt77LJO69EfZT3s3CAfe0hks7fFpZ8SIqw50F2K5ed7o4CswewPlvsA0yeZCOHZWFk0X2rRSWzfgz7TOAfim37HYp/kYQWFi8XYpd93Q5uPSVId6CX/dJoGfFNHx4oY/lsKQKbYo=
-node_js: '6'
+node_js: stable
 addons:
   firefox: latest
   apt:
@@ -18,7 +17,10 @@ addons:
       - google-chrome
     packages:
       - google-chrome-stable
+  sauce_connect: true
 script:
-  - xvfb-run wct
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'
+  - xvfb-run polymer test
+  - >-
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
+    fi
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ thing! https://github.com/PolymerLabs/tedium/issues
 -->
 
 [![Build status](https://travis-ci.org/PolymerElements/gold-cc-expiration-input.svg?branch=master)](https://travis-ci.org/PolymerElements/gold-cc-expiration-input)
+[![Demo and API Docs](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/PolymerElements/gold-cc-expiration-input)
 
-_[Demo and API docs](https://elements.polymer-project.org/elements/gold-cc-expiration-input)_
-
-
-##&lt;gold-cc-expiration-input&gt;
+## &lt;gold-cc-expiration-input&gt;
 
 `gold-cc-expiration-input` is a  single-line text field with Material Design styling
 for entering a credit card's expiration date

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gold-cc-expiration-input",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "A validating input for a credit card expiration date",
   "authors": [
     "The Polymer Authors"
@@ -21,20 +21,43 @@
   "homepage": "https://github.com/PolymerElements/gold-cc-expiration-input",
   "ignore": [],
   "dependencies": {
-    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.1.2",
-    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
-    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
-    "paper-input": "PolymerElements/paper-input#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
-    "polymer": "Polymer/polymer#^1.1.0"
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#1 - 2",
+    "iron-input": "PolymerElements/iron-input#1 - 2",
+    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#1 - 2",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#1 - 2",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#1 - 2",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#1 - 2",
+    "paper-input": "PolymerElements/paper-input#1 - 2",
+    "paper-styles": "PolymerElements/paper-styles#1 - 2",
+    "polymer": "Polymer/polymer#1.9 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
+        "iron-input": "PolymerElements/iron-input#^1.0.0",
+        "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
+        "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
+        "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+        "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
+        "paper-input": "PolymerElements/paper-input#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "polymer": "Polymer/polymer#^1.1.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "web-component-tester": "^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
   }
 }

--- a/date-input.html
+++ b/date-input.html
@@ -22,13 +22,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <style>
       span {
-        @apply(--paper-input-container-font);
+        @apply --paper-input-container-font;
         opacity: 0.33;
         text-align: center;
       }
 
-      input[is="iron-input"] {
-        position: relative; /* to make a stacking context */
+      input {
         outline: none;
         box-shadow: none;
         padding: 0;
@@ -38,13 +37,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         color: var(--paper-input-container-input-color, --primary-text-color);
         text-align: center;
 
-        @apply(--layout-flex);
-        @apply(--paper-font-subhead);
-        @apply(--paper-input-container-input);
+        @apply --layout-flex;
+        @apply --paper-font-subhead;
+        @apply --paper-input-container-input;
+      }
+
+      iron-input {
+        @apply --layout-flex;
       }
 
       .container {
-        @apply(--layout-horizontal);
+        @apply --layout-horizontal;
       }
     </style>
 
@@ -54,160 +57,309 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <span aria-hidden id="yearLabel" hidden>Year</span>
 
     <div class="container">
-      <input is="iron-input"
-          id="expirationMonth"
-          aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'monthLabel')]]"
-          required$="[[required]]"
-          maxlength="2"
-          bind-value="{{month}}"
-          placeholder="MM"
-          allowed-pattern="[0-9]"
-          prevent-invalid-input
-          autocomplete="cc-exp-month"
-          type="tel"
-          disabled$="[[disabled]]"
-          invalid="{{invalid}}"
-          autofocus$="[[autofocus]]"
-          inputmode$="[[inputmode]]"
-          readonly$="[[readonly]]">
-      <span>/</span>
-      <input is="iron-input"
-          id="expirationYear"
-          aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'yearLabel')]]"
-          required$="[[required]]"
-          maxlength="2"
-          bind-value="{{year}}"
-          placeholder="YY"
-          allowed-pattern="[0-9]"
-          prevent-invalid-input
-          autocomplete="cc-exp-year"
-          type="tel"
-          disabled$="[[disabled]]"
-          invalid="{{invalid}}"
-          inputmode$="[[inputmode]]"
-          readonly$="[[readonly]]">
+      <span id="template-placeholder"></span>
     </div>
   </template>
 
+  <template id="v0">
+    <input is="iron-input" id="expirationMonth"
+        on-input="_onInputMonth"
+        aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'monthLabel')]]"
+        required$="[[required]]"
+        maxlength="2"
+        bind-value="{{month}}"
+        placeholder="MM"
+        allowed-pattern="[0-9]"
+        prevent-invalid-input
+        autocomplete="cc-exp-month"
+        type="tel"
+        disabled$="[[disabled]]"
+        invalid="{{invalid}}"
+        autofocus$="[[autofocus]]"
+        inputmode$="[[inputmode]]"
+        readonly$="[[readonly]]">
+    <span>/</span>
+    <input is="iron-input" id="expirationYear"
+        on-input="_onInputYear"
+        aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'yearLabel')]]"
+        required$="[[required]]"
+        maxlength="2"
+        bind-value="{{year}}"
+        placeholder="YY"
+        allowed-pattern="[0-9]"
+        prevent-invalid-input
+        autocomplete="cc-exp-year"
+        type="tel"
+        disabled$="[[disabled]]"
+        invalid="{{invalid}}"
+        inputmode$="[[inputmode]]"
+        readonly$="[[readonly]]">
+  </template>
+
+  <template id="v1">
+    <iron-input
+        allowed-pattern="[0-9]"
+        bind-value="{{month}}"
+        invalid="{{invalid}}">
+      <input id="expirationMonth"
+          on-input="_onInputMonth"
+          aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'monthLabel')]]"
+          required$="[[required]]"
+          maxlength="2"
+          placeholder="MM"
+          autocomplete="cc-exp-month"
+          type="tel"
+          disabled$="[[disabled]]"
+          autofocus$="[[autofocus]]"
+          inputmode$="[[inputmode]]"
+          readonly$="[[readonly]]">
+    </iron-input>
+    <span>/</span>
+    <iron-input
+        allowed-pattern="[0-9]"
+        bind-value="{{year}}"
+        invalid="{{invalid}}">
+      <input id="expirationYear"
+          on-input="_onInputYear"
+          aria-labelledby$="[[_computeAriaLabel(ariaLabelPrefix,'yearLabel')]]"
+          required$="[[required]]"
+          maxlength="2"
+          placeholder="YY"
+          autocomplete="cc-exp-year"
+          type="tel"
+          disabled$="[[disabled]]"
+          inputmode$="[[inputmode]]"
+          readonly$="[[readonly]]">
+    </iron-input>
+  </template>
+
+  <script>
+    Polymer({
+
+      is: 'date-input',
+
+      behaviors: [
+        Polymer.IronA11yKeysBehavior,
+        Polymer.IronValidatableBehavior
+      ],
+
+      properties: {
+        /**
+         * Set to true to mark the input as required.
+         */
+        required: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Set to true to auto-validate the input value.
+         */
+        autoValidate: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * The month component of the date displayed.
+         */
+        month: {
+          type: String
+        },
+
+        /**
+         * The year component of the date displayed.
+         */
+        year: {
+          type: String
+        },
+
+        /**
+         * The date object used by the validator. Has two properties, month and year.
+         * `gold-cc-expiration-input` also uses the Object to update its value
+         */
+        date: {
+          notify: true,
+          type: Object
+        },
+
+        /**
+         * Overriden from IronValidatableBehavior
+         */
+        validator: {
+          type: String,
+          value: 'date-validator'
+        },
+
+        ariaLabelPrefix: {
+          type: String
+        },
+
+        /**
+         * Set to true to disable the month and year input elements.
+         */
+        disabled: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Set to true to autofocus the month input element.
+         */
+        autofocus: {
+          type: Boolean
+        },
+
+        /**
+         * Bound to the month and year input elements' `inputmode` property.
+         */
+        inputmode: {
+          type: String
+        },
+
+        /**
+         * Set to true to mark the month and year inputs as not editable.
+         */
+        readonly: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Overriden from IronA11yKeysBehavior
+         */
+        stopKeyboardEventPropagation: {
+          type: Boolean,
+          value: true
+        },
+
+        /**
+         * Prevents changes to the `date` property
+         */
+        stopDateEventPropagation: {
+          type: Boolean,
+          value: false
+        }
+      },
+
+      keyBindings: {
+        '/': '_focusYear',
+        'shift+tab:keydown': '_onShiftTabDown'
+      },
+
+      observers: [
+        '_valuesChanged(month, year, stopDateEventPropagation, autoValidate)'
+      ],
+
+      beforeRegister: function() {
+        var template = Polymer.DomModule.import('date-input', 'template');
+        var version = Polymer.Element ? 'v1' : 'v0';
+        var inputTemplate = Polymer.DomModule.import('date-input',
+          'template#' + version);
+        var inputPlaceholder = template.content.querySelector(
+          '#template-placeholder');
+        if (inputPlaceholder) {
+          inputPlaceholder.parentNode.replaceChild(inputTemplate.content,
+            inputPlaceholder);
+        }
+      },
+
+      _focusYear: function() {
+        this.$.expirationYear.focus();
+      },
+
+      /**
+       * If needed, sets `month`, `year`, and `date` properties and performs
+       * validation
+       */
+      _setMonthAndYear(month, year, validate) {
+        var oldDate = this.date || {};
+        var monthChanged = month !== oldDate.month;
+        var yearChanged = year !== oldDate.year;
+        if (monthChanged || yearChanged) {
+          var date = {
+            month: month,
+            year: year
+          };
+          if (Polymer.Element) {
+            this.setProperties({
+              "month": month,
+              "year": year,
+              "date": date
+            });
+          } else {
+            this.month = month;
+            this.year = year;
+            this.date = date;
+          }
+          if (validate) {
+            this.validate();
+          }
+        }
+      },
+
+      /**
+       * Handles changes that require `date` computation or validation
+       */
+      _valuesChanged: function(month, year, stopDateEventPropagation,
+          autoValidate) {
+        if (typeof(stopDateEventPropagation) === "undefined"
+            || stopDateEventPropagation) {
+          return;
+        }
+        this._setMonthAndYear(month, year, autoValidate);
+      },
+
+      /**
+       * Handles month input events
+       */
+      _onInputMonth: function(e) {
+        this._onInputMonthOrYear(e);
+        if (this.month && this.month.length === 2) {
+          this._focusYear();
+        }
+      },
+
+      /**
+       * Handles year input events
+       */
+      _onInputYear: function(e) {
+        this._onInputMonthOrYear(e);
+      },
+
+      /**
+       * Handles month or year input events
+       */
+      _onInputMonthOrYear: function(e) {
+        var month = this.$.expirationMonth.value;
+        var year = this.$.expirationYear.value;
+        this._setMonthAndYear(month, year, this.autoValidate);
+      },
+
+      validate: function() {
+        // Empty, non-required input is valid.
+        if (!this.required && this.month == '' && this.year == '') {
+          return true;
+        }
+        this.invalid = !this.$.validator.validate(this.date);
+        this.fire('iron-input-validate');
+        return !this.invalid;
+      },
+
+      _computeAriaLabel: function(dateLabel, monthLabel) {
+        return dateLabel + ' ' + monthLabel;
+      },
+
+      /**
+       * This event was propagating to PaperInputBehavior and causing
+       * tabindex problems
+       *
+       * see https://github.com/PolymerElements/paper-input/blob/master/paper-input-behavior.html#L459
+       */
+      _onShiftTabDown: function(e) {
+        e.stopPropagation();
+      }
+    });
+  </script>
+
 </dom-module>
-
-<script>
-  Polymer({
-
-    is: 'date-input',
-
-    behaviors: [
-      Polymer.IronA11yKeysBehavior,
-      Polymer.IronValidatableBehavior
-    ],
-
-    properties: {
-      /**
-       * Set to true to mark the input as required.
-       */
-      required: {
-        type: Boolean,
-        value: false
-      },
-
-      /**
-       * The month component of the date displayed.
-       */
-      month: {
-        type: String,
-        value: ''
-      },
-
-      /**
-       * The year component of the date displayed.
-       */
-      year: {
-        type: String,
-        value: ''
-      },
-
-      /**
-       * The date object used by the validator. Has two properties, month and year.
-       */
-      date: {
-        notify: true,
-        type: Object
-      },
-
-      validator: {
-        type: String,
-        value: 'date-validator'
-      },
-
-      ariaLabelPrefix: {
-        type:String
-      },
-
-      /**
-       * Set to true to disable the month and year input elements.
-       */
-      disabled: {
-        type: Boolean,
-        value: false
-      },
-
-      /**
-       * Set to true to autofocus the month input element.
-       */
-      autofocus: {
-        type: Boolean
-      },
-
-      /**
-       * Bound to the month and year input elements' `inputmode` property.
-       */
-      inputmode: {
-        type: String
-      },
-
-      /**
-       * Set to true to mark the month and year inputs as not editable.
-       */
-      readonly: {
-        type: Boolean,
-        value: false
-      }
-    },
-
-    keyBindings: {
-      '/': '_selectYear'
-    },
-
-    observers: [
-      '_computeDate(month, year)'
-    ],
-
-    _selectYear: function() {
-      this.$.expirationYear.focus();
-    },
-
-    _computeDate: function(month, year) {
-      // Months are 0-11.
-      this.date = {month: month, year: year};
-      this.fire('dateChanged', this.date);
-      // Advance cursor to year after month entry
-      if (month && month.length === 2) {
-        this._selectYear();
-      }
-    },
-
-    validate: function() {
-      // Empty, non-required input is valid.
-      if (!this.required && this.month == '' && this.year == '') {
-        return true;
-      }
-      this.invalid = !this.$.validator.validate(this.date);
-      this.fire('iron-input-validate');
-      return !this.invalid;
-    },
-
-    _computeAriaLabel: function(dateLabel, monthLabel) {
-      return dateLabel + ' ' + monthLabel;
-    }
-  });
-</script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -33,19 +33,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h4>Standard</h4>
     <div class="vertical-section">
       <gold-cc-expiration-input></gold-cc-expiration-input>
-      <gold-cc-expiration-input label="Auto-validating" auto-validate required></gold-cc-expiration-input>
+      <gold-cc-expiration-input value="07/20"></gold-cc-expiration-input>
     </div>
 
     <h4>Pre-validated</h4>
     <div class="vertical-section">
-      <gold-cc-expiration-input auto-validate value="11/15"></gold-cc-expiration-input>
+      <gold-cc-expiration-input auto-validate value="11/20"></gold-cc-expiration-input>
       <gold-cc-expiration-input auto-validate value="31/23"></gold-cc-expiration-input>
       <gold-cc-expiration-input auto-validate value="11/"></gold-cc-expiration-input>
+      <gold-cc-expiration-input label="Required" required auto-validate></gold-cc-expiration-input>
     </div>
 
-    <h4>Custom error message, auto-validates on blur</h4>
+    <h4>Custom error message, validates on blur</h4>
     <div class="vertical-section">
-      <gold-cc-expiration-input required auto-validate error-message="Please enter a valid date" label="Credit Card Expiration"></gold-cc-expiration-input>
+      <gold-cc-expiration-input required error-message="Please enter a valid date" label="Credit Card Expiration"></gold-cc-expiration-input>
+      <gold-cc-expiration-input value="31/23" error-message="Please enter a valid date"></gold-cc-expiration-input>
     </div>
   </div>
 </body>

--- a/gold-cc-expiration-input.html
+++ b/gold-cc-expiration-input.html
@@ -61,16 +61,20 @@ style this element.
 
     <paper-input-container id="container"
         no-label-float="[[noLabelFloat]]"
-        always-float-label="[[alwaysFloatLabel]]"
+        always-float-label
         attr-for-value="date"
         disabled$="[[disabled]]"
         invalid="[[invalid]]">
 
-      <label hidden$="[[!label]]">[[label]]</label>
+      <label slot="label" hidden$="[[!label]]">[[label]]</label>
 
       <date-input class="paper-input-input" id="input"
+          stop-date-event-propagation$="[[!_observeDateChange]]"
+          date="{{date}}"
+          slot="input"
           aria-label-prefix="[[_ariaLabelledBy]]"
           required$="[[required]]"
+          auto-validate="[[autoValidate]]"
           autocomplete$="[[autocomplete]]"
           disabled$="[[disabled]]"
           invalid="{{invalid}}"
@@ -81,7 +85,7 @@ style this element.
       </date-input>
 
       <template is="dom-if" if="[[errorMessage]]">
-        <paper-input-error>[[errorMessage]]</paper-input-error>
+        <paper-input-error slot="add-on">[[errorMessage]]</paper-input-error>
       </template>
 
     </paper-input-container>
@@ -93,11 +97,6 @@ style this element.
       Polymer({
 
         is: 'gold-cc-expiration-input',
-
-        /* The underlying dateInput is tabbable */
-        hostAttributes: {
-          'tabindex': -1
-        },
 
         behaviors: [
           Polymer.PaperInputBehavior,
@@ -113,56 +112,69 @@ style this element.
             value: "Expiration Date"
           },
 
+          /**
+           * The value as 'mm/yy'
+           */
           value: {
             type: String,
-            value: '',
-            observer: '_onValueChanged'
+            notify: true,
+            value: ''
+          },
+
+          /**
+           * The value as an object with a 'month' and 'year' property
+           */
+          date: {
+            type: Object,
+            notify: true,
+            observer: '_onDateChanged'
+          },
+
+          /**
+           * Composed date-input will not publish changes to its `date` property
+           * until `_observeDateChange` is true. This prevents the `date` property
+           * observer from incorrectly stepping-on the initial `value` property
+           */
+          _observeDateChange: {
+            type: Boolean,
+            value: false
           }
         },
 
-        listeners: {
-          'dateChanged': '_dateChanged'
-        },
-
         observers: [
-          '_onFocusedChanged(focused)'
+          '_onFocusedChanged(focused)',
+          '_onValueChanged(value, _observeDateChange)'
         ],
 
         ready: function() {
-          // If there's an initial input, validate it.
-          if (this.value)
-            this._handleAutoValidate();
+          this._observeDateChange = true;
+          /**
+           * PaperInputBehavior's tabindex=0 seems to cause problems
+           * the natural tabindex from date-input's native inputs should prevail
+           */
+          this.removeAttribute('tabindex');
         },
 
         /**
          * A handler that is called on input
          */
-        _onValueChanged: function(value, oldValue) {
-          // The initial property assignment is handled by `ready`.
-          if (oldValue == undefined)
-            return;
-
-          this.$.input.month = this._computeMonth(value);
-          this.$.input.year = this._computeYear(value);
-          this._handleAutoValidate();
+        _onValueChanged: function(value, ready) {
+          var parts = (value || '').split('/');
+          var input = this.$.input;
+          input.month = parts[0];
+          input.year = parts[1];
         },
 
-        _dateChanged: function(event) {
-          var month = event.detail.month || '';
-          var year = event.detail.year || '';
+        /**
+         * Handles Date change events published by `date-input` by updating the
+         * `value` property
+         */
+        _onDateChanged: function(d) {
+          d = d || {};
+          var month = d.month || '';
+          var year = d.year || '';
           var value = year ? (month + '/' + year) : month;
-
           this.value = String(value);
-        },
-
-        _computeMonth: function(value) {
-          // Date is in MM/YY format.
-          return value.split('/')[0];
-        },
-
-        _computeYear: function(value) {
-          // Date is in MM/YY format.
-          return value.split('/')[1] || '';
         },
 
         /**
@@ -176,15 +188,15 @@ style this element.
          * Overidden from Polymer.IronControlState.
          */
         _onFocusedChanged: function(focused) {
-          if (!focused) {
-            this._handleAutoValidate();
+          var previouslyFocused = this._previouslyFocused || false;
+          this._previouslyFocused = focused || previouslyFocused;
+          if (!focused && previouslyFocused) {
+            this.validate();
           }
         }
-          
       })
 
     })();
-
   </script>
 
 </dom-module>

--- a/test/basic.html
+++ b/test/basic.html
@@ -35,132 +35,186 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="manualValidate">
+    <template>
+      <gold-cc-expiration-input required error-message="error"></gold-cc-expiration-input>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('basic', function() {
-      test('invalid input is not ok', function() {
+      test('invalid input is not ok', function(done) {
         var input = fixture('basic');
-        input.value='1234';
-        forceXIfStamp(input);
+        Polymer.Base.async(function() {
+          input.value='1234';
+          forceXIfStamp(input);
 
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        assert.ok(container, 'paper-input-container exists');
-        assert.isTrue(container.invalid);
+          var container = Polymer.dom(input.root).querySelector('paper-input-container');
+          assert.ok(container, 'paper-input-container exists');
+          assert.isTrue(container.invalid);
 
-        var error = Polymer.dom(input.root).querySelector('paper-input-error');
-        assert.ok(error, 'paper-input-error exists');
-        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+          var error = Polymer.dom(input.root).querySelector('paper-input-error');
+          assert.ok(error, 'paper-input-error exists');
+          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+
+          done();
+        }, 1);
       });
 
-      test('misformed dates are not ok', function() {
+      test('misformed dates are not ok', function(done) {
         var input = fixture('basic');
-        input.value='33/33';
-        forceXIfStamp(input);
+        Polymer.Base.async(function() {
+          input.value='33/33';
+          forceXIfStamp(input);
 
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        assert.ok(container, 'paper-input-container exists');
-        assert.isTrue(container.invalid);
+          var container = Polymer.dom(input.root).querySelector('paper-input-container');
+          assert.ok(container, 'paper-input-container exists');
+          assert.isTrue(container.invalid);
 
-        var error = Polymer.dom(input.root).querySelector('paper-input-error');
-        assert.ok(error, 'paper-input-error exists');
-        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+          var error = Polymer.dom(input.root).querySelector('paper-input-error');
+          assert.ok(error, 'paper-input-error exists');
+          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+
+          done();
+        }, 1);
       });
 
-      test('past dates are not ok', function() {
+      test('past dates are not ok', function(done) {
         var input = fixture('basic');
-        input.value='11/00';
-        forceXIfStamp(input);
+        Polymer.Base.async(function() {
+          input.value='11/00';
+          forceXIfStamp(input);
 
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        assert.ok(container, 'paper-input-container exists');
-        assert.isTrue(container.invalid);
+          var container = Polymer.dom(input.root).querySelector('paper-input-container');
+          assert.ok(container, 'paper-input-container exists');
+          assert.isTrue(container.invalid);
 
-        var error = Polymer.dom(input.root).querySelector('paper-input-error');
-        assert.ok(error, 'paper-input-error exists');
-        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+          var error = Polymer.dom(input.root).querySelector('paper-input-error');
+          assert.ok(error, 'paper-input-error exists');
+          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+
+          done();
+        }, 1);
       });
 
-      test('future dates are ok', function() {
+      test('future dates are ok', function(done) {
         var input = fixture('basic');
-        // Note: this test will start failing in 2099. Apologies, future maintainers.
-        input.value='11/99';
-        forceXIfStamp(input);
+        Polymer.Base.async(function() {
+          // Note: this test will start failing in 2099. Apologies, future maintainers.
+          input.value='11/99';
+          forceXIfStamp(input);
 
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        assert.ok(container, 'paper-input-container exists');
-        assert.isFalse(container.invalid);
-        assert.equal(input.value, '11/99');
+          var container = Polymer.dom(input.root).querySelector('paper-input-container');
+          assert.ok(container, 'paper-input-container exists');
+          assert.isFalse(container.invalid);
+          assert.equal(input.value, '11/99');
 
-        var error = Polymer.dom(input.root).querySelector('paper-input-error');
-        assert.ok(error, 'paper-input-error exists');
-        assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+          var error = Polymer.dom(input.root).querySelector('paper-input-error');
+          assert.ok(error, 'paper-input-error exists');
+          assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+
+          done();
+        }, 1);
       });
 
-      test('value is updated correctly ', function() {
+      test('value is updated correctly ', function(done) {
         var input = fixture('basic');
-        input.$$('.paper-input-input').month = 11;
-        input.$$('.paper-input-input').year = 15;
-        assert.equal(input.value, '11/15');
+        Polymer.Base.async(function() {
+          forceXIfStamp(input);
+
+          var dateInput = Polymer.dom(input.root).querySelector('date-input');
+          dateInput.month = 11;
+          dateInput.year = 15;
+          assert.equal(input.value, '11/15');
+
+          done();
+        }, 1);
+      });
+
+      test('empty required input shows error if autovalidating', function(done) {
+        var input = fixture('basic');
+        Polymer.Base.async(function() {
+          forceXIfStamp(input);
+
+          var container = Polymer.dom(input.root).querySelector('paper-input-container');
+          assert.ok(container, 'paper-input-container exists');
+          assert.isTrue(container.invalid);
+
+          var error = Polymer.dom(input.root).querySelector('paper-input-error');
+          assert.ok(error, 'paper-input-error exists');
+          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+          done();
+        }, 1);
       });
 
       test('empty required input shows error on blur', function(done) {
+        var input = fixture('manualValidate');
+        Polymer.Base.async(function() {
+          forceXIfStamp(input);
+
+          var error = Polymer.dom(input.root).querySelector('paper-input-error');
+          assert.ok(error, 'paper-input-error exists');
+          assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+          input.addEventListener('blur', function(event) {
+            assert(!input.focused, 'input is blurred');
+            assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+            done();
+          });
+          MockInteractions.focus(input.inputElement);
+          MockInteractions.blur(input.inputElement);
+        }, 1);
+      });
+
+      test('placeholder shows correctly', function(done) {
         var input = fixture('basic');
-        forceXIfStamp(input);
-
-        var error = Polymer.dom(input.root).querySelector('paper-input-error');
-        assert.ok(error, 'paper-input-error exists');
-
-        assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
-
-        input.addEventListener('blur', function(event) {
-          assert(!input.focused, 'input is blurred');
-          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+        Polymer.Base.async(function() {
+          forceXIfStamp(input);
+          var dateInput = Polymer.dom(input.root).querySelector('date-input');
+          var month = Polymer.dom(dateInput.root).querySelector('#expirationMonth');
+          var year = Polymer.dom(dateInput.root).querySelector('#expirationYear');
+          assert.equal(month.placeholder, 'MM', 'month placeholder is MM');
+          assert.equal(year.placeholder, 'YY', 'year placeholder is YY');
           done();
-        });
-        MockInteractions.focus(input.inputElement);
-        MockInteractions.blur(input.inputElement);
+        }, 1);
       });
 
-      test('placeholder shows correctly', function() {
+      test('/ key advances to year input', function(done) {
         var input = fixture('basic');
-        forceXIfStamp(input);
-        var dateInput = Polymer.dom(input.root).querySelector('date-input');
-        var month = Polymer.dom(dateInput.root).querySelector('#expirationMonth');
-        var year = Polymer.dom(dateInput.root).querySelector('#expirationYear');
-        assert.equal(month.placeholder, 'MM', 'month placeholder is MM');
-        assert.equal(year.placeholder, 'YY', 'year placeholder is YY');
-      });
-
-      test('/ key advances to year input', function() {
-        var input = fixture('basic');
-        forceXIfStamp(input);
-        var dateInput = Polymer.dom(input.root).querySelector('date-input');
-        var year = Polymer.dom(dateInput.root).querySelector('#expirationYear');
-        MockInteractions.pressAndReleaseKeyOn(dateInput, 191, [], '/');
-        assert.equal(Polymer.dom(dateInput.root).activeElement, year, 'year is focused');
+        Polymer.Base.async(function() {
+          forceXIfStamp(input);
+          var dateInput = Polymer.dom(input.root).querySelector('date-input');
+          var year = Polymer.dom(dateInput.root).querySelector('#expirationYear');
+          MockInteractions.pressAndReleaseKeyOn(dateInput, 191, [], '/');
+          assert.equal(Polymer.dom(dateInput.root).activeElement, year, 'year is focused');
+          done();
+        }, 1);
       });
 
     });
 
     suite('a11y', function() {
 
-      test('has aria-labelledby', function() {
+      test('has aria-labelledby', function(done) {
         var input = fixture('basic');
-        var dateInput = input.$$('.paper-input-input');
-        var month = dateInput.$$('input:nth-of-type(1)');
-        var year = dateInput.$$('input:nth-of-type(2)');
-        var label = Polymer.dom(input.root).querySelector('label').id;
+        Polymer.Base.async(function() {
+          var dateInput = input.$$('.paper-input-input');
+          var dateInput = Polymer.dom(input.root).querySelector('date-input');
+          var month = Polymer.dom(dateInput.root).querySelector('#expirationMonth');
+          var year = Polymer.dom(dateInput.root).querySelector('#expirationYear');
+          var label = Polymer.dom(input.root).querySelector('label').id;
 
-        assert.ok(month);
-        assert.ok(year);
+          assert.ok(month);
+          assert.ok(year);
 
-        assert.isTrue(month.hasAttribute('aria-labelledby'));
-        assert.isTrue(year.hasAttribute('aria-labelledby'));
+          assert.isTrue(month.hasAttribute('aria-labelledby'));
+          assert.isTrue(year.hasAttribute('aria-labelledby'));
 
-        assert.equal(month.getAttribute('aria-labelledby'), label + ' monthLabel');
-        assert.equal(year.getAttribute('aria-labelledby'), label + ' yearLabel');
+          assert.equal(month.getAttribute('aria-labelledby'), label + ' monthLabel');
+          assert.equal(year.getAttribute('aria-labelledby'), label + ' yearLabel');
+          done();
+        }, 1);
       });
-
     });
 
 

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     WCT.loadSuites([
-      'basic.html',
+      'basic.html?wc-shadydom=true&wc-ce=true',
       'basic.html?dom=shadow'
     ]);
   </script>


### PR DESCRIPTION
## Overview

Fixes #59 and #61 

At some point I reviewed #62 but found it to have far to many issues

I'm JUST NOW seeing #63 doh!! Maybe @e111077 and I can compare notes

There were a couple of tricky issues here whose solutions I'm not too thrilled about... please let me know if you have alternative suggestions. Details follow -

### Tabindex

I could not seem to get tabindexing to work properly except by explicitly removing the tabindex attribute from the `ready` callback.

The tabindex host attribute of `0` inherited from `PaperInputBehavior` would focus the `gold-cc-expiration-input` but not the inputs within `date-input`.

The overridden (in v1) tabindex host attribute of `-1` would prevent focus completely. Additionally, I seem to recall having trouble overriding the tabindex inherited from `PaperInputBehavior`... although that may have been due to an issue I encountered later...

`PaperInputBehavior` is doing some tabindex sorcery when a shift-tab key combo is entered  [https://github.com/PolymerElements/paper-input/blob/master/paper-input-behavior.html#L460](here).  I think that code should change to `removeAttribute` rather than `setAttribute` when replacing the previous tabindex value. `shift-tab` would be a typical key combo for this element, so I ended up preventing propagation of that key combo.

### Value consistency

Issue #59 was caused by issues with the order of events flowing between `gold-cc-expiration-input` and `date-input`. For example:

- Initial value of '01/20' set on `gold-cc-expiration-input`
- `date-input` publishes a change to its `date` property (based on its `month` and `year` properties) which are empty
- `gold-cc-expiration-input` processes the `date-changed` event by updating its local `value` property... to be empty
- `date-input` has an empty value rather than '01/20'

There was lots of "whack-a-mole" trying to resolve consistency issues made evident by manual and automated tests. At some point I tried making `date-input` publish _all_ of the properties (value, month, year). Handling synchronization among all of them started to feel impossible. Although this would break existing consumers that were using the `date-input` directly (rather than gold-cc-expiration-input), I would propose making the month and year properties read-only and allowing data-binding via a string `value` property.

The solution I ended up implementing was one where `date-input` will not publish `date-change` events until `gold-cc-expiration-input` has had a chance to push its initial value down.

### AutoValidating

I had a difficult time reasoning about how exactly auto-validating should work. It seems that this component has _always_ auto-validated (on blur). Judging from the previous demos, the auto-validate attribute for this component is meant to serve as a sort of "auto validate and pre validate initial values".
